### PR TITLE
Add String withQuotes extension

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Bug fix 🐛
+      labels:
+        - bugfix
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,22 @@
+name: Swift
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Unit tests
+      run: swift test
+
+  changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3

--- a/.gitignore
+++ b/.gitignore
@@ -37,14 +37,14 @@ playground.xcworkspace
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
-# Package.resolved
-# *.xcodeproj
+Packages/
+Package.pins
+Package.resolved
+*.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
+.swiftpm
 
 .build/
 

--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.5]
+
+- Add `addQuotes` String extension

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
-# Fast
+# Fast ![](https://github.com/ahcode0919/Fast/actions/workflows/swift.yml/badge.svg?branch=main)
 
 A collection of helpful Swift extensions and utilities
+
+## Usage
+
+- Add to following to your project's Swift Package Manager dependencies: `https://github.com/ahcode0919/Fast.git`
+
+## Features
+
+### String
+
+- `chomp()` - Removes white space from the start and end of a String
+- `withQuotes` - Encapsulates a String in quotations 

--- a/Sources/Fast/Extensions/String+Extension.swift
+++ b/Sources/Fast/Extensions/String+Extension.swift
@@ -8,7 +8,19 @@
 import Foundation
 
 public extension String {
+    
+    /// Removes whitespace and Newlines from the beginning and ending of the String
+    /// - Returns: String without whitespace at the beginning or end
     func chomp() -> String {
         return self.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    
+    /// Adds quotes to a string, fill ignore if the string is already quoted
+    /// - Returns: Quoted string "{String}"
+    func withQuotes() -> String {
+        if let first = self.first, let last = self.last, first == "\"", last == "\"" {
+            return self
+        }
+        return "\"\(self)\""
     }
 }

--- a/Tests/FastTests/String+ExtensionTests.swift
+++ b/Tests/FastTests/String+ExtensionTests.swift
@@ -9,4 +9,10 @@ final class StringExtensionTests: XCTestCase {
         XCTAssertEqual("test \n\r  ".chomp(), "test")
         XCTAssertEqual("test    \n ".chomp(), "test")
     }
+
+    func testWithQuotes() {
+        XCTAssertEqual("foo".withQuotes(), "\"foo\"")
+        XCTAssertEqual("".withQuotes(), "\"\"")
+        XCTAssertEqual("\"foo\"".withQuotes(), "\"foo\"")
+    }
 }


### PR DESCRIPTION
Add `withQuotes` String extension. Encapsulates a string in quotation marks.

- Update `CHANGELOG.md`
- Update `README.md`
- Add Github Actions scripts
- Remove `.swiftpm` files
- Update `.gitignore` with `.swiftpm` related files